### PR TITLE
Add separate brightness controls for sun/moon icons

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,8 @@
 {
   "theme": "succulent",
-  "brightness_day":   1.0, 
-  "brightness_night": 0.7 
+  "brightness_day":   1.0,
+  "brightness_night": 0.7,
+  "brightness_sun":   1.0,
+  "brightness_moon":  0.7
 }
 


### PR DESCRIPTION
## Summary
- allow configuration of sun and moon icon brightness
- apply brightness and drift logic to sun and moon images
- update documentation comment

## Testing
- `python -m py_compile clock.py`