### PR TITLE
Add configurable centered temperature display

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,11 @@
   "brightness_night": 0.7,
   "brightness_sun":   1.0,
   "brightness_moon":  0.7
+  ,"temp_brightness_day": 1.0
+  ,"temp_brightness_night": 1.0
+  ,"temp_color_day": [255,255,255]
+  ,"temp_color_night": [255,255,255]
+  ,"temp_font_size": 64
+  ,"temp_padding_top": 40
 }
 


### PR DESCRIPTION
## Summary
- allow configuring font size and top padding for temperature
- center the temperature text at the top of the screen
- move TOP_RESERVED calculation after font loading
- update example configuration

## Testing
- `python3 -m py_compile clock.py`
