### PR TITLE
Add temperature endpoint support

### DIFF
--- a/clock.py
+++ b/clock.py
@@ -7,10 +7,11 @@ Themed fullscreen image clock 1920×1080
 • HH:MM am/pm  (colon + am/pm = half-width)
 • Per-theme brightness
 • Separate sun/moon brightness
+• Temperature readout with independent brightness and color
 • Anti burn-in drift
 """
 
-import json, os, pathlib, random, sys
+import json, os, pathlib, random, sys, urllib.request
 from datetime import datetime, timedelta
 
 import pygame
@@ -34,6 +35,8 @@ DEFAULT_THEME         = "default"
 TOUCH_DURATION        = timedelta(milliseconds=300)
 TOUCH_RADIUS          = 40
 TOUCH_COLOR           = (255, 255, 255)
+TEMP_FONT_SIZE       = 64
+DEFAULT_TEMP_URL     = "http://snek:8000/habitat/api/most_recent"
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─── LOAD CONFIG ─────────────────────────────────────────────────────────────
@@ -48,9 +51,15 @@ def load_config(path):
     b_night = clamp(data.get("brightness_night", 1.0))
     b_sun   = clamp(data.get("brightness_sun",   1.0))
     b_moon  = clamp(data.get("brightness_moon",  1.0))
-    return theme, b_day, b_night, b_sun, b_moon
+    b_temp_day   = clamp(data.get("temp_brightness_day",   1.0))
+    b_temp_night = clamp(data.get("temp_brightness_night", 1.0))
+    col_day  = tuple(data.get("temp_color_day",  [255, 255, 255]))
+    col_night= tuple(data.get("temp_color_night", [255, 255, 255]))
+    temp_url = data.get("temp_url", DEFAULT_TEMP_URL)
+    return (theme, b_day, b_night, b_sun, b_moon,
+            b_temp_day, b_temp_night, col_day, col_night, temp_url)
 
-THEME_NAME, B_DAY, B_NIGHT, B_SUN, B_MOON = load_config(CONFIG_PATH)
+THEME_NAME, B_DAY, B_NIGHT, B_SUN, B_MOON, B_TEMP_DAY, B_TEMP_NIGHT, TEMP_COL_DAY, TEMP_COL_NIGHT, TEMP_URL = load_config(CONFIG_PATH)
 THEME_DIR = IMAGES_ROOT / THEME_NAME
 if not THEME_DIR.exists():
     sys.exit(f"Theme '{THEME_NAME}' not found at {THEME_DIR}")
@@ -101,6 +110,29 @@ MOON_ICONS = {
 
 MAX_ICON_H   = max(i.get_height() for i in (*SUN_ICONS.values(), *MOON_ICONS.values()))
 TOP_RESERVED = MAX_ICON_H + 2*PADDING
+
+
+# ─── TEMPERATURE ─────────────────────────────────────────────────────────────
+_temp_cache = None
+_temp_time = datetime.min
+_temp_interval = timedelta(minutes=5)
+
+def get_temperature():
+    """Return current temperature in °F from TEMP_URL."""
+    global _temp_cache, _temp_time
+    now = datetime.now()
+    if now - _temp_time > _temp_interval:
+        try:
+            with urllib.request.urlopen(TEMP_URL, timeout=5) as r:
+                data = json.loads(r.read().decode())
+                _temp_cache = float(data.get("Temperature", _temp_cache or 0))
+        except Exception:
+            pass
+        _temp_time = now
+    return _temp_cache if _temp_cache is not None else 0.0
+
+font_path = pygame.font.match_font("comicsansms")
+TEMP_FONT = pygame.font.Font(font_path or None, TEMP_FONT_SIZE)
 
 
 # ─── MOON-PHASE → FILENAME (8-way) ───────────────────────────────────────────
@@ -157,6 +189,7 @@ def base_origin():
 
 origin, next_shift = base_origin(), datetime.now(tz)+DRIFT_PERIOD
 icon_offset = (0,0)
+temp_offset = (0,0)
 touches = []
 
 def glyph_seq(dt):
@@ -173,6 +206,15 @@ while running:
     theme_key = "day" if is_day else "night"
     glyphs    = DIGITS[theme_key]
 
+    temp_val  = get_temperature()
+    temp_txt  = f"{temp_val:.0f}\N{DEGREE SIGN}F"
+    raw_col   = TEMP_COL_DAY if is_day else TEMP_COL_NIGHT
+    bright    = B_TEMP_DAY if is_day else B_TEMP_NIGHT
+    col       = tuple(min(255, int(c*bright)) for c in raw_col)
+    temp_surf = TEMP_FONT.render(temp_txt, True, col)
+    temp_x    = PADDING + temp_offset[0]
+    temp_y    = PADDING + (MAX_ICON_H - temp_surf.get_height())//2 + temp_offset[1]
+
     # corner icon
     if is_day:
         icon = SUN_ICONS[now.strftime("%A").lower()]
@@ -188,6 +230,8 @@ while running:
                 by+random.randint(-DRIFT_PIXELS,DRIFT_PIXELS))
         icon_offset=(random.randint(-DRIFT_PIXELS,DRIFT_PIXELS),
                      random.randint(-DRIFT_PIXELS,DRIFT_PIXELS))
+        temp_offset=(random.randint(-DRIFT_PIXELS,DRIFT_PIXELS),
+                     random.randint(-DRIFT_PIXELS,DRIFT_PIXELS))
         next_shift = now + DRIFT_PERIOD
 
     for e in pygame.event.get():
@@ -201,6 +245,7 @@ while running:
     # draw
     screen.fill((0,0,0))
     screen.blit(icon,(icon_x,icon_y))
+    screen.blit(temp_surf,(temp_x,temp_y))
     x,y=origin
     for k in glyph_seq(now):
         screen.blit(glyphs[k],(x,y))

--- a/config.json
+++ b/config.json
@@ -4,5 +4,10 @@
   "brightness_night": 0.7,
   "brightness_sun":   1.0,
   "brightness_moon":  0.7
+  ,"temp_brightness_day": 1.0
+  ,"temp_brightness_night": 1.0
+  ,"temp_color_day": [255,255,255]
+  ,"temp_color_night": [255,255,255]
+  ,"temp_url": "http://snek:8000/habitat/api/most_recent"
 }
 


### PR DESCRIPTION
## Summary
- allow fetching temperature from configurable endpoint
- parse `temp_url` in config.json
- cache temperature for 5 minutes and use configured brightness/color

## Testing
- `python3 -m py_compile clock.py`
