### PR TITLE
Add temperature fetch from endpoint

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,5 +10,6 @@
   ,"temp_color_night": [255,255,255]
   ,"temp_font_size": 64
   ,"temp_padding_top": 40
+  ,"temp_endpoint": "http://snek:8000/habitat/api/most_recent"
 }
 


### PR DESCRIPTION
## Summary
- enable configurable temperature endpoint via `config.json`
- read temperature from the endpoint using `urllib.request`

## Testing
- `python3 -m py_compile clock.py`
