### PR TITLE
Add weather icon functionality

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,6 +12,8 @@
   ,"temp_padding_top": 40
   ,"temp_endpoint": "http://snek:8000/habitat/api/most_recent"
   ,"temp_network_period": 120
+  ,"brightness_weather": 1.0
+  ,"weather_endpoint": "http://snek:8000/weather/api/most_recent"
   ,"weather_network_period": 900
 }
 


### PR DESCRIPTION
## Summary
- add weather brightness, endpoint, and fetch interval settings
- load weather icons and display on screen
- fetch weather data periodically from `http://snek:8000/weather/api/most_recent`
- drift weather icon for burn‑in protection
- move day/night icon to the opposite side

## Testing
- `python3 -m py_compile clock.py`
