### PR TITLE
Add day/night weather brightness config

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,7 +12,8 @@
   ,"temp_padding_top": 40
   ,"temp_endpoint": "http://snek:8000/habitat/api/most_recent"
   ,"temp_network_period": 120
-  ,"brightness_weather": 1.0
+  ,"brightness_weather_day": 1.0
+  ,"brightness_weather_night": 0.7
   ,"weather_endpoint": "http://snek:8000/weather/api/most_recent"
   ,"weather_network_period": 900
 }


### PR DESCRIPTION
## Summary
- allow separate brightness settings for day and night weather icons
- update config.json to include new settings

## Testing
- `python3 -m py_compile clock.py`
- `python3 -m json.tool config.json >/dev/null`
